### PR TITLE
Add AiAnnotation model

### DIFF
--- a/app/models/ai_annotation.rb
+++ b/app/models/ai_annotation.rb
@@ -1,0 +1,16 @@
+class AiAnnotation < ApplicationRecord
+  before_create :clean_old_annotations
+  before_create :set_uuid
+
+  scope :old, -> { where("created_at < ?", 1.day.ago) }
+
+  private
+
+  def clean_old_annotations
+    AiAnnotation.old.destroy_all
+  end
+
+  def set_uuid
+    self.uuid = SecureRandom.uuid
+  end
+end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,7 @@
+# Async adapter only works within the same process, so for manually triggering cable updates from a console,
+# and seeing results in the browser, you must do so from the web console (running inside the dev process),
+# not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
+# to make the web console appear.
+
+test:
+  adapter: test

--- a/db/migrate/20250307021604_create_ai_annotations.rb
+++ b/db/migrate/20250307021604_create_ai_annotations.rb
@@ -1,0 +1,10 @@
+class CreateAiAnnotations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ai_annotations do |t|
+      t.string :uuid, null: false
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_07_021604) do
+  create_table "ai_annotations", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/test/models/ai_annotation_test.rb
+++ b/test/models/ai_annotation_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class AiAnnotationTest < ActiveSupport::TestCase
+  test "should delete old annotation when creating new instance" do
+    AiAnnotation.create!(content: "aaa", created_at: 2.days.ago)
+    AiAnnotation.create!(content: "bbb")
+
+    assert AiAnnotation.exists?(content: "bbb")
+    assert_not AiAnnotation.exists?(content: "aaa")
+  end
+end


### PR DESCRIPTION
Closes: #2

## 概要
LLMが生成したインラインアノテーションを保存するAiAnnotationモデルを作成しました。

## 作業内容
- AiAnnotationテーブルの作成
  - カラムはuuidとcontent
- AiAnnotationモデルの作成
  - レコード作成時にuuidをセット
  - レコード作成時に1日以上前に作成されたレコードを削除
- モデルテストの追加