### PR TITLE
Add show page for textae with ai annotation

### DIFF
--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,5 +1,5 @@
 class AiAnnotationsController < ApplicationController
   def show
-    @ai_annotation = AiAnnotation.find_by!(uuid: params[:id])
+    @ai_annotation = AiAnnotation.find_by!(uuid: params[:uuid])
   end
 end

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,0 +1,5 @@
+class AiAnnotationsController < ApplicationController
+  def show
+    @ai_annotation = AiAnnotation.find_by!(uuid: params[:id])
+  end
+end

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,5 +1,5 @@
 class AiAnnotationsController < ApplicationController
   def show
-    @ai_annotation = AiAnnotation.find_by!(uuid: params[:uuid])
+    @ai_annotation = AiAnnotation.find_by!(uuid: params[:uuid]).content
   end
 end

--- a/app/views/ai_annotations/show.html.erb
+++ b/app/views/ai_annotations/show.html.erb
@@ -1,0 +1,3 @@
+<div class="textae-editor" mode="edit">
+  <%= @ai_annotation %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,8 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <script src="https://textae.pubannotation.org/lib/textae-13.8.1.min.js"></script>
+    <link rel="stylesheet" href="https://textae.pubannotation.org/lib/css/textae-13.8.1.min.css">
   </head>
 
   <body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+
+  get "/ai_annotations/:uuid" => "ai_annotations#show"
 end


### PR DESCRIPTION
Closes: #5 

## 概要
プロンプトによるアノテーション結果表示ページを作成しました。

※ 結果表示ページにはプロンプト窓も用意して再度アノテーションをつけれるようにしますが、その機能は別で実装したいと考えています。今回のPRではプロンプト窓は用意しませんでした。

## 作業内容
- アノテーション結果表示ページの作成
  - パス：/ai_annotations/:uuid

## 動作確認
現時点ではAiAnnotationsController#showの`@ai_annotation`が取得できず404になりますが、以下のように仮の値を設定してTextAEが起動することを確認しました。
```
  def show
    # @ai_annotation = AiAnnotation.find_by!(uuid: params[:id])
    @ai_annotation = <<~MD
    [Elon Musk][Person] is a member of the [PayPal Mafia][Organization].

    [Person]: https://example.com/Person
    [Organization]: https://example.com/Organization
    MD
  end
```

|<img width="750" alt="image" src="https://github.com/user-attachments/assets/06cbe819-cda2-425b-b4be-2baf942d84cc" />|
|:-|