### PR TITLE
Apply style to all pages

### DIFF
--- a/app/assets/stylesheets/ai_annotation.css
+++ b/app/assets/stylesheets/ai_annotation.css
@@ -1,15 +1,17 @@
 .ai-annotation-form {
-  margin-top: 40px;
+  margin-top: 30px;
 
   label {
     display: block;
+    font-family: sans-serif, verdana, arial, helvetica;
     font-size: 1.5rem;
     font-weight: bold;
-    color: rgb(46, 46, 46);
+    color: rgb(56, 56, 56);
   }
 
   textarea {
     width: 100%;
+    font-family: verdana, arial, helvetica, sans-serif;
     font-size: 1rem;
     padding: 10px;
     border: solid 1px #D9D9D9;
@@ -25,7 +27,7 @@
   }
 
   .prompt-field {
-    margin-top: 20px;
+    margin-top: 30px;
   }
 
   .submit-field {
@@ -37,9 +39,11 @@
 }
 
 .textae-container {
-  margin-top: 20px;
+  margin-top: 40px;
 
   .textae-editor {
+    max-height: 600px;
+    overflow-y: scroll;
     border: solid 1px #D9D9D9;
     border-radius: 12px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -53,7 +57,7 @@
 .button {
   padding: 8px 16px;
   border-radius: 9999px;
-  background-color: black;
+  background-color: rgb(56, 56, 56);
   color: white;
   border: none;
   font-size: 0.875rem;

--- a/app/assets/stylesheets/ai_annotation.css
+++ b/app/assets/stylesheets/ai_annotation.css
@@ -1,6 +1,4 @@
 .ai-annotation-form {
-  width: 60%;
-  margin: auto;
   margin-top: 40px;
 
   label {
@@ -35,6 +33,20 @@
     display: flex;
     justify-content: end;
     margin-top: 5px;
+  }
+}
+
+.textae-container {
+  margin-top: 20px;
+
+  .textae-editor {
+    border: solid 1px #D9D9D9;
+    border-radius: 12px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+    .textae-control-bar {
+      border-radius: 12px 12px 0 0;
+    }
   }
 }
 

--- a/app/assets/stylesheets/ai_annotation.css
+++ b/app/assets/stylesheets/ai_annotation.css
@@ -1,0 +1,60 @@
+.ai-annotation-form {
+  width: 60%;
+  margin: auto;
+  margin-top: 40px;
+
+  label {
+    display: block;
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: rgb(46, 46, 46);
+  }
+
+  textarea {
+    width: 100%;
+    font-size: 1rem;
+    padding: 10px;
+    border: solid 1px #D9D9D9;
+    border-radius: 12px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    resize: none;
+
+    &:focus {
+      outline: none;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+      transition: all 0.2s ease-in-out;
+    }
+  }
+
+  .prompt-field {
+    margin-top: 20px;
+  }
+
+  .submit-field {
+    width: 100%;
+    display: flex;
+    justify-content: end;
+    margin-top: 5px;
+  }
+}
+
+.button {
+  padding: 8px 16px;
+  border-radius: 9999px;
+  background-color: black;
+  color: white;
+  border: none;
+  font-size: 0.875rem;
+  line-height: 20px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #4C4C4C;
+  }
+
+  &:disabled {
+    background-color: #8a909c;
+    pointer-events: none;
+    opacity: 0.6;
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,7 +15,35 @@
   padding: 0;
 }
 
-body {
+header {
+  background-color: white;
+  padding: 12px 0;
+  border-bottom: 1px solid rgb(74, 74, 74);
+
+  .inner {
+    width: 80%;
+    margin: auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    a {
+      color: rgb(74, 74, 74);
+      text-decoration: none;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    .logo a {
+      font-weight: bold;
+      font-size: 1.75rem;
+    }
+  }
+}
+
+.content {
   width: 80%;
   margin: auto;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,6 +15,11 @@
   padding: 0;
 }
 
+body {
+  width: 80%;
+  margin: auto;
+}
+
 .flash.alert {
   background-color: #f8d7da;
   color: #721c24;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,7 +9,13 @@
  * Consider organizing styles into separate files for maintainability.
  */
 
- .flash.alert {
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+.flash.alert {
   background-color: #f8d7da;
   color: #721c24;
   border: 1px solid #f5c6cb;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -45,6 +45,10 @@ header {
       font-weight: bold;
       font-size: 1.75rem;
     }
+
+    .new-text-link {
+      display: block;
+    }
   }
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,10 +15,14 @@
   padding: 0;
 }
 
+body {
+  font-family: verdana, arial, helvetica, sans-serif;
+}
+
 header {
   background-color: white;
   padding: 12px 0;
-  border-bottom: 1px solid rgb(74, 74, 74);
+  border-bottom: 1px solid rgb(56, 56, 56);
 
   .inner {
     width: 80%;
@@ -28,7 +32,7 @@ header {
     justify-content: space-between;
 
     a {
-      color: rgb(74, 74, 74);
+      color: rgb(56, 56, 56);
       text-decoration: none;
 
       &:hover {
@@ -37,6 +41,7 @@ header {
     }
 
     .logo a {
+      font-family: sans-serif, verdana, arial, helvetica;
       font-weight: bold;
       font-size: 1.75rem;
     }
@@ -46,10 +51,14 @@ header {
 .content {
   width: 80%;
   margin: auto;
+  margin-bottom: 40px;
 }
 
 .flash.alert {
+  margin-top: 20px;
+  padding: 10px;
   background-color: #f8d7da;
   color: #721c24;
   border: 1px solid #f5c6cb;
+  border-radius: 12px;
 }

--- a/app/views/ai_annotations/new.html.erb
+++ b/app/views/ai_annotations/new.html.erb
@@ -1,18 +1,18 @@
 <%# When post with turbo, TextAE events does not work correctly on redirected page. %>
 <%# To fix this problem, turning off turbo. %>
 <%= form_with url: ai_annotations_path, method: :post, data: { turbo: false }, class: "ai-annotation-form" do |f| %>
-  <div>
-    <label style="display: block">Text</label>
-    <%= f.textarea :text, required: true, rows: 5, class: "text-input", style: "width: 80%;" %>
+  <div class="text-field">
+    <label>Text</label>
+    <%= f.textarea :text, required: true, rows: 15, placeholder: "Write or paste text here" %>
   </div>
 
-  <div>
-    <label style="display: block;">Prompt</label>
-    <%= f.textarea :prompt, required: true, rows: 2, class: "prompt-input", style: "width: 80%;" %>
+  <div class="prompt-field">
+    <label>Prompt</label>
+    <%= f.textarea :prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
   </div>
 
-    <div>
-    <%= f.submit "Submit", disabled: true, class: "submit-button" %>
+  <div class="submit-field">
+    <%= f.submit "Annotate", disabled: true, class: "button" %>
   </div>
 <% end %>
 

--- a/app/views/ai_annotations/show.html.erb
+++ b/app/views/ai_annotations/show.html.erb
@@ -1,20 +1,21 @@
-<div id="ai-textae-editor" mode="edit">
-  <%= @ai_annotation.content %>
+<div class="textae-container">
+  <div id="ai-textae-editor" mode="edit">
+    <%= @ai_annotation.content %>
+  </div>
 </div>
 
 <%# When post with turbo, TextAE events does not work correctly on redirected page. %>
 <%# To fix this problem, turning off turbo. %>
 <%= form_with url: ai_annotations_path, method: :post, data: { turbo: false }, class: "ai-annotation-form" do |f| %>
-  <div>
-    <label style="display: block;">Prompt</label>
-    <%= f.textarea :prompt, required: true, rows: 2, style: "width: 80%;" %>
+  <div class="prompt-field">
+    <%= f.textarea :prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
   </div>
 
   <%= f.hidden_field :uuid, value: @ai_annotation.uuid %>
   <%= f.hidden_field :textae_annotation, id: 'textae-annotation' %>
 
-  <div>
-    <%= f.submit "Submit", disabled: true %>
+  <div class="submit-field">
+    <%= f.submit "Annotate", disabled: true, class: "button" %>
   </div>
 <% end %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,12 @@
+<header>
+  <div class="inner">
+    <div class="logo">
+      <%= link_to "TextAE Canvas", root_path %>
+    </div>
+    <% unless controller_name == "ai_annotations" && action_name == "new" %>
+      <div>
+        <%= link_to "New Text", root_path %>
+      </div>
+    <% end %>
+  </div>
+</header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,10 +3,6 @@
     <div class="logo">
       <%= link_to "TextAE Canvas", root_path %>
     </div>
-    <% unless controller_name == "ai_annotations" && action_name == "new" %>
-      <div>
-        <%= link_to "New Text", root_path %>
-      </div>
-    <% end %>
+    <%= link_to "New Text", root_path, class: "new-text-link" unless current_page?(controller: "ai_annotations", action: "new") %>
   </div>
 </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,8 @@
   </head>
 
   <body>
+    <%= render "layouts/header" %>
+
     <div class="content">
       <% if alert %>
         <div class="flash alert"><%= alert %></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,11 +25,11 @@
   </head>
 
   <body>
-    <% if alert %>
-      <div class="flash alert"><%= alert %></div>
-    <% end %>
-
     <div class="content">
+      <% if alert %>
+        <div class="flash alert"><%= alert %></div>
+      <% end %>
+
       <%= yield %>
     </div>
   </body>


### PR DESCRIPTION
Closes: #11

## 概要
初期画面と結果表示画面のスタイル当てを行いました。

## 作業内容
- ヘッダーの追加
- 初期画面にスタイルを適用
- 結果表示画面にスタイルを適用

## 画面の確認
### 初期画面
|<img width="1430" alt="image" src="https://github.com/user-attachments/assets/4b62334b-3a5e-4179-bbf2-70e0e7a3cf4e" />|
|:-|

### 結果表示画面
|<img width="1428" alt="image" src="https://github.com/user-attachments/assets/4b85bde0-872a-4ffd-90cd-3b5f2bde2276" />|
|:-|

### エラー時
|<img width="1416" alt="image" src="https://github.com/user-attachments/assets/a41a65d5-95bc-40b5-9f50-528f089cc071" />|
|:-|

|<img width="1412" alt="image" src="https://github.com/user-attachments/assets/f9cf1a29-a45a-4ce8-95eb-dd991e8a19d7" />|
|:-|