### PR TITLE
Remove turbo-rails to fix javascript problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ gem "sqlite3", ">= 2.1"
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,9 +291,6 @@ GEM
     stringio (3.1.5)
     thor (1.3.2)
     timeout (0.4.3)
-    turbo-rails (2.0.13)
-      actionpack (>= 7.1.0)
-      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
@@ -342,7 +339,6 @@ DEPENDENCIES
   selenium-webdriver
   sqlite3 (>= 2.1)
   stimulus-rails
-  turbo-rails
   tzinfo-data
   web-console
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
 import "controllers"

--- a/app/javascript/initFormValidation.js
+++ b/app/javascript/initFormValidation.js
@@ -1,4 +1,4 @@
-const initFormValidation = () => {
+document.addEventListener("DOMContentLoaded", () => {
   const form = document.querySelector(".ai-annotation-form")
   if (!form) return
 
@@ -12,7 +12,4 @@ const initFormValidation = () => {
   if (prompt) {
     prompt.addEventListener("input", enableSubmitButton)
   }
-}
-
-document.addEventListener("turbo:load", initFormValidation)
-document.addEventListener("turbo:render", initFormValidation)
+})

--- a/app/views/ai_annotations/new.html.erb
+++ b/app/views/ai_annotations/new.html.erb
@@ -1,6 +1,4 @@
-<%# When post with turbo, TextAE events does not work correctly on redirected page. %>
-<%# To fix this problem, turning off turbo. %>
-<%= form_with url: ai_annotations_path, method: :post, data: { turbo: false }, class: "ai-annotation-form" do |f| %>
+<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do |f| %>
   <div class="text-field">
     <label>Text</label>
     <%= f.textarea :text, required: true, rows: 15, placeholder: "Write or paste text here" %>

--- a/app/views/ai_annotations/show.html.erb
+++ b/app/views/ai_annotations/show.html.erb
@@ -4,9 +4,7 @@
   </div>
 </div>
 
-<%# When post with turbo, TextAE events does not work correctly on redirected page. %>
-<%# To fix this problem, turning off turbo. %>
-<%= form_with url: ai_annotations_path, method: :post, data: { turbo: false }, class: "ai-annotation-form" do |f| %>
+<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do |f| %>
   <div class="prompt-field">
     <%= f.textarea :prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <link rel="apple-touch-icon" href="/icon.png">
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag :app %>
     <%= javascript_importmap_tags %>
     <script src="https://textae.pubannotation.org/lib/textae-13.8.1.min.js"></script>
     <link rel="stylesheet" href="https://textae.pubannotation.org/lib/css/textae-13.8.1.min.css">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,7 +1,6 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
-pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
Closes: #15 

## 概要
ブラウザの戻るボタンを使ってページ遷移するとTextAEが正しく動作しない問題を修正しました。
turbo-railsをアプリから削除することで対応しました。

また、issueに記載している「formのdisabledの制御が、値が入っているにも関わらずdisabledになる」問題ですが、こちらはメイン機能の開発中には起きていたのですが、今回改めて確認すると再現しませんでした。
Turboの有無で直ったわけではないようですが、どこかのタイミングで直った可能性があります。この件は再現しないのでひとまず対応不要と判断しました。

## 作業内容
- turbo-railsの削除
- turbo系のイベントリスナーを設定していた箇所をDOMContentLoadedイベントで発火するように変更
- form_withで指定していたturbo: falseの設定を削除

## 動作確認
### 戻るボタンで遷移してもTextAEが正常に動作する

https://github.com/user-attachments/assets/1ea72b3f-a750-4f41-b270-f9096341f956

