### PR TITLE
Rename application name

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Textae Ai" %></title>
+    <title><%= content_for(:title) || "TextAE Canvas" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "TextaeAi",
+  "name": "TextAECanvas",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "TextaeAi.",
+  "description": "TextAECanvas.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module TextaeAi
+module TextAECanvas
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0


### PR DESCRIPTION
## 概要
Railsアプリ名をTextaeAiからTextAE Canvasに変更しました。

## 作業内容
- ブラウザタイトルを変更
- その他ディレクトリ内の旧アプリ名を使っている箇所の変更

## 修正後のブラウザタイトル
<img width="223" alt="image" src="https://github.com/user-attachments/assets/80ea95cf-93b6-4ab8-8419-82344e5aea88" />
