### PR TITLE
Revise format specification

### DIFF
--- a/app/models/ai_annotation.rb
+++ b/app/models/ai_annotation.rb
@@ -1,28 +1,24 @@
 class AiAnnotation < ApplicationRecord
   FORMAT_SPECIFICATION = <<~EOS
-    Annotate text using the following syntax:
+    Annotate the text according to the prompt with using the following syntax:
 
-    ## Annotation Structure
-    - An annotation is represented by two consecutive pairs of square brackets:
-      - First pair: annotated text
-      - Second pair: label
+    ## Annotation Format
+    - An annotation consists of two consecutive square bracket pairs:
+      - First: annotated text
+      - Second: label
     - Example: [Annotated Text][Label]
 
     ## Label Definition (Optional)
-    - Define labels with a square bracket followed by `:` and a URL.
-    - Example: [Label]: URL
+    - Labels can be defined as `[Label]: URL`.
 
-    ## Metacharacter Escaping
-    - The annotation structure (two consecutive pairs of square brackets) is rarely appear in normal text.
-      If it does occur, it may be misinterpreted as an annotation.
-      To avoid this, the first opening square bracket must be escaped with a backslash (\).
-    - Example: \[This is a part of][original text]
+    ## Escaping Metacharacters
+    - To prevent misinterpretation, escape the first `[` if it naturally occurs.
+    - Example: \[Part of][Original Text]
 
     ## Handling Unknown Prompts
-    - If you do not understand the prompt or cannot generate annotations, return the text exactly as it is without any modifications or additional messages.
+    - If could not understand prompt, return the input text unchanged.
 
-    Follow the prompt for annotation labels.
-    Output should be the original text with annotations.
+    Output the original text with annotations.
   EOS
 
   before_create :clean_old_annotations
@@ -39,7 +35,7 @@ class AiAnnotation < ApplicationRecord
         model: "gpt-4o",
         messages: [
           { role: "system", content: FORMAT_SPECIFICATION },
-          { role: "user", content: "Text:\n#{text}\n\nPrompt:\n#{prompt}" }
+          { role: "user", content: "#{text}\n\nPrompt:\n#{prompt}" }
         ]
       }
     )

--- a/app/models/ai_annotation.rb
+++ b/app/models/ai_annotation.rb
@@ -18,6 +18,9 @@ class AiAnnotation < ApplicationRecord
       To avoid this, the first opening square bracket must be escaped with a backslash (\).
     - Example: \[This is a part of][original text]
 
+    ## Handling Unknown Prompts
+    - If you do not understand the prompt or cannot generate annotations, return the text exactly as it is without any modifications or additional messages.
+
     Follow the prompt for annotation labels.
     Output should be the original text with annotations.
   EOS
@@ -36,7 +39,7 @@ class AiAnnotation < ApplicationRecord
         model: "gpt-4o",
         messages: [
           { role: "system", content: FORMAT_SPECIFICATION },
-          { role: "user", content: "text: #{text} prompt: #{prompt}" }
+          { role: "user", content: "Text:\n#{text}\n\nPrompt:\n#{prompt}" }
         ]
       }
     )


### PR DESCRIPTION
## 概要
LLMに送るフォーマットの前提指示を改善しました。

## 作業内容
-  プロンプトが理解不能だった場合に、理解不能だったというメッセージがTextAEで表示される問題を修正
   - 理解不要だった場合は元のテキストをそのまま返す指示を追加
-   トークン量削減のためにフォーマット指示を簡素化、整理

## 動作確認
### プロンプトが理解不能な場合
修正前はプロンプトが理解不能だった場合に理解不能だったというメッセージがTextAEに表示されていました。
修正後は入力テキストがそのまま返るようになっています。
|<img width="900" alt="image" src="https://github.com/user-attachments/assets/5e5ca205-39aa-4925-b529-6d6011929ca5" />|
|:-|

|<img width="900" alt="image" src="https://github.com/user-attachments/assets/d764095c-536b-459f-a7fa-f1439faf19b1" />|
|:-|

### フォーマット指示の改善結果
OpenAIのトークン計算ツールを使用して、修正前と修正後でトークン数を比較しました。
https://platform.openai.com/tokenizer

#### 修正前
<img width="600" alt="image" src="https://github.com/user-attachments/assets/7d197f75-e0fa-4059-8288-25377caa0d21" />

#### 修正後
<img width="600" alt="image" src="https://github.com/user-attachments/assets/76236c50-80b3-4591-9546-c298f48aff1b" />

40トークン程度ですが削減できました。
修正後にアノテーション動作の確認を行いましたが、特に悪い影響はなさそうでした。

画像：「病名をアノテートして」と送った結果
|<img width="1196" alt="image" src="https://github.com/user-attachments/assets/001253e3-2244-4567-9c08-b4efd90871ef" />|
|:-|

