### PR TITLE
Keep form values when error occured

### DIFF
--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,25 +1,35 @@
 class AiAnnotationsController < ApplicationController
   def show
     @ai_annotation = AiAnnotation.find_by!(uuid: params[:uuid])
+    @new_ai_annotation = AiAnnotation.new
   end
 
-  def new; end
+  def new
+    @new_ai_annotation = AiAnnotation.new
+  end
 
   def create
-    @text = params[:text] || AnnotationConverter.new.to_inline(params[:textae_annotation])
-    @prompt = params[:prompt]
-    ai_annotation = AiAnnotation.generate!(@text, @prompt)
+    text = ai_annotation_params[:text] || AnnotationConverter.new.to_inline(ai_annotation_params[:textae_annotation])
+    prompt = ai_annotation_params[:prompt]
+    @new_ai_annotation = AiAnnotation.prepare_with(text, prompt)
+    ai_annotation = @new_ai_annotation.annotate!
 
     redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
-    @ai_annotation = AiAnnotation.find_by(uuid: params[:uuid])
+    @ai_annotation = AiAnnotation.find_by(uuid: ai_annotation_params[:uuid])
 
     if @ai_annotation
       render :show, status: :unprocessable_entity
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def ai_annotation_params
+    params.require(:ai_annotation).permit(:text, :prompt, :uuid, :textae_annotation)
   end
 end

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -6,9 +6,9 @@ class AiAnnotationsController < ApplicationController
   def new; end
 
   def create
-    text = params[:text] || AnnotationConverter.new.to_inline(params[:textae_annotation])
-    prompt = params[:prompt]
-    ai_annotation = AiAnnotation.generate!(text, prompt)
+    @text = params[:text] || AnnotationConverter.new.to_inline(params[:textae_annotation])
+    @prompt = params[:prompt]
+    ai_annotation = AiAnnotation.generate!(@text, @prompt)
 
     redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e

--- a/app/javascript/initFormValidation.js
+++ b/app/javascript/initFormValidation.js
@@ -2,14 +2,18 @@ document.addEventListener("DOMContentLoaded", () => {
   const form = document.querySelector(".ai-annotation-form")
   if (!form) return
 
-  const { text, prompt, commit } = form.elements
+  const { ai_annotation_text, ai_annotation_prompt, commit } = form.elements
   const enableSubmitButton = () => commit.disabled = !form.checkValidity()
 
-  if (text) {
-    text.addEventListener("input", enableSubmitButton)
+  if (ai_annotation_text) {
+    ai_annotation_text.addEventListener("input", enableSubmitButton)
   }
 
-  if (prompt) {
-    prompt.addEventListener("input", enableSubmitButton)
+  if (ai_annotation_prompt) {
+    ai_annotation_prompt.addEventListener("input", enableSubmitButton)
   }
+
+  // Run form check once at loading to handle situations
+  // where values are assigned from the time of loading, such as in the case of validation errors.
+  enableSubmitButton()
 })

--- a/app/javascript/initFormValidation.js
+++ b/app/javascript/initFormValidation.js
@@ -12,8 +12,4 @@ document.addEventListener("DOMContentLoaded", () => {
   if (ai_annotation_prompt) {
     ai_annotation_prompt.addEventListener("input", enableSubmitButton)
   }
-
-  // Run form check once at loading to handle situations
-  // where values are assigned from the time of loading, such as in the case of validation errors.
-  enableSubmitButton()
 })

--- a/app/views/ai_annotations/new.html.erb
+++ b/app/views/ai_annotations/new.html.erb
@@ -1,16 +1,16 @@
-<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do %>
+<%= form_with model: @new_ai_annotation, class: "ai-annotation-form" do |f| %>
   <div class="text-field">
     <label>Text</label>
-    <%= text_area_tag :text,  @text, required: true, rows: 15, placeholder: "Write or paste text here" %>
+    <%= f.textarea :text, required: true, rows: 15, placeholder: "Write or paste text here" %>
   </div>
 
   <div class="prompt-field">
     <label>Prompt</label>
-    <%= text_area_tag :prompt, @prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
+    <%= f.textarea :prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
   </div>
 
   <div class="submit-field">
-    <%= submit_tag "Annotate", disabled: true, class: "button" %>
+    <%= f.submit "Annotate", disabled: true, class: "button" %>
   </div>
 <% end %>
 

--- a/app/views/ai_annotations/new.html.erb
+++ b/app/views/ai_annotations/new.html.erb
@@ -1,16 +1,16 @@
-<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do |f| %>
+<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do %>
   <div class="text-field">
     <label>Text</label>
-    <%= f.textarea :text, required: true, rows: 15, placeholder: "Write or paste text here" %>
+    <%= text_area_tag :text,  @text, required: true, rows: 15, placeholder: "Write or paste text here" %>
   </div>
 
   <div class="prompt-field">
     <label>Prompt</label>
-    <%= f.textarea :prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
+    <%= text_area_tag :prompt, @prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
   </div>
 
   <div class="submit-field">
-    <%= f.submit "Annotate", disabled: true, class: "button" %>
+    <%= submit_tag "Annotate", disabled: true, class: "button" %>
   </div>
 <% end %>
 

--- a/app/views/ai_annotations/show.html.erb
+++ b/app/views/ai_annotations/show.html.erb
@@ -4,16 +4,16 @@
   </div>
 </div>
 
-<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do |f| %>
+<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do %>
   <div class="prompt-field">
-    <%= f.textarea :prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
+    <%= text_area_tag :prompt, @prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
   </div>
 
-  <%= f.hidden_field :uuid, value: @ai_annotation.uuid %>
-  <%= f.hidden_field :textae_annotation, id: 'textae-annotation' %>
+  <%= hidden_field_tag :uuid, @ai_annotation.uuid %>
+  <%= hidden_field_tag :textae_annotation, nil, id: 'textae-annotation' %>
 
   <div class="submit-field">
-    <%= f.submit "Annotate", disabled: true, class: "button" %>
+    <%= submit_tag "Annotate", disabled: true, class: "button" %>
   </div>
 <% end %>
 

--- a/app/views/ai_annotations/show.html.erb
+++ b/app/views/ai_annotations/show.html.erb
@@ -4,16 +4,16 @@
   </div>
 </div>
 
-<%= form_with url: ai_annotations_path, method: :post, class: "ai-annotation-form" do %>
+<%= form_with model: @new_ai_annotation, class: "ai-annotation-form" do |f| %>
   <div class="prompt-field">
-    <%= text_area_tag :prompt, @prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
+    <%= f.textarea :prompt, required: true, rows: 3, placeholder: "Order how to annotate the text" %>
   </div>
 
-  <%= hidden_field_tag :uuid, @ai_annotation.uuid %>
-  <%= hidden_field_tag :textae_annotation, nil, id: 'textae-annotation' %>
+  <%= f.hidden_field :uuid, value: @ai_annotation.uuid %>
+  <%= f.hidden_field :textae_annotation, id: 'textae-annotation' %>
 
   <div class="submit-field">
-    <%= submit_tag "Annotate", disabled: true, class: "button" %>
+    <%= f.submit "Annotate", disabled: true, class: "button" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
## 概要
アノテーション作成失敗時にフォームに入力していた値が保持できない問題がありました。
これを保持できるように修正しました。

### 対応方法
通常、フォームの入力値を保持するためにはモデルオブジェクトをコントローラーで生成し、フォームと関連付けることで実現することが一般的だと思われます。
今回の場合はフォーム項目がモデルのカラムと直接対応しないため上記方法では不可能です。

対応方法として以下の2つが考えられ、シンプルに対応できる点から1つ目を選択しました。
- create時のtextとpromptをインスタンス変数に代入するようにし、viewでtextareaの値にセットする
- 専用のフォームオブジェクトを使用する

対応方法に問題がないか、別の対応方法が良い等ありましたらコメントお願いします。

## 作業内容
- AiAnnotationsController#createのtext, prompt変数をインスタンス変数化
- new, showのビューでtext, promptインスタンス変数をフォームの値にすることで、エラー時に値を保持する仕組みを追加

## 動作確認
### newページ
|<img width="1341" alt="image" src="https://github.com/user-attachments/assets/b375bfba-0813-4f52-83c8-84c2217f1942" />|
|:-|

### showページ
|<img width="1301" alt="image" src="https://github.com/user-attachments/assets/2d04932d-39b2-43fd-9276-68e39a054066" />|
|:-|