### PR TITLE
Fix form disabled button problem

### DIFF
--- a/app/javascript/initFormValidation.js
+++ b/app/javascript/initFormValidation.js
@@ -12,4 +12,8 @@ document.addEventListener("DOMContentLoaded", () => {
   if (ai_annotation_prompt) {
     ai_annotation_prompt.addEventListener("input", enableSubmitButton)
   }
+
+  // Sometimes form may be in a valid state on loaded timing. (e.g., due to errors or browser back)
+  // execute enableSubmitButton function once to ensure the submit button is set correctly.
+  enableSubmitButton()
 })


### PR DESCRIPTION
## 概要
フォームがエラー時などで際レンダリングされる時に、フォームに値が入っているにもかかわらずsubmitボタンがdisabledのままになる問題がありました。
この問題を修正しました。

## 動作確認
### 修正前
エラー時にAnnotateボタンがdisabledになってしまっています。
再度送信するにはinputイベントを発火させてJSの処理を再度行わせる必要がありました。
|<img width="1373" alt="image" src="https://github.com/user-attachments/assets/b83a7a94-e063-416f-81e7-a9862212035f" />|
|:-|

### 修正後
エラー時にもAnnotateボタンが期待する状態になるようになりました。
|<img width="1367" alt="image" src="https://github.com/user-attachments/assets/e352db2d-9348-4674-a1e5-70550375706d" />|
|:-|